### PR TITLE
Add parameter system with APVTS

### DIFF
--- a/source/ParameterIDs.h
+++ b/source/ParameterIDs.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+namespace ParameterIDs
+{
+    inline const juce::String mix          { "mix" };
+    inline const juce::String rateMultiplier { "rateMultiplier" };
+    inline const juce::String manualRate   { "manualRate" };
+    inline const juce::String mode         { "mode" };
+    inline const juce::String smoothing    { "smoothing" };
+    inline const juce::String sensitivity  { "sensitivity" };
+    inline const juce::String waveform     { "waveform" };
+}

--- a/source/PluginProcessor.cpp
+++ b/source/PluginProcessor.cpp
@@ -1,11 +1,67 @@
 #include "PluginProcessor.h"
 #include "PluginEditor.h"
+#include "ParameterIDs.h"
 
 HdnRingmodAudioProcessor::HdnRingmodAudioProcessor()
     : AudioProcessor(BusesProperties()
                          .withInput("Input", juce::AudioChannelSet::stereo(), true)
-                         .withOutput("Output", juce::AudioChannelSet::stereo(), true))
+                         .withOutput("Output", juce::AudioChannelSet::stereo(), true)),
+      apvts(*this, nullptr, "Parameters", createParameterLayout())
 {
+}
+
+juce::AudioProcessorValueTreeState::ParameterLayout HdnRingmodAudioProcessor::createParameterLayout()
+{
+    juce::AudioProcessorValueTreeState::ParameterLayout layout;
+
+    layout.add(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID(ParameterIDs::mix, 1),
+        "Mix",
+        juce::NormalisableRange<float>(0.0f, 100.0f, 0.1f),
+        50.0f,
+        juce::AudioParameterFloatAttributes().withLabel("%")));
+
+    layout.add(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID(ParameterIDs::rateMultiplier, 1),
+        "Rate Multiplier",
+        juce::NormalisableRange<float>(0.1f, 8.0f, 0.01f, 0.5f),
+        1.0f,
+        juce::AudioParameterFloatAttributes().withLabel("x")));
+
+    layout.add(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID(ParameterIDs::manualRate, 1),
+        "Manual Rate",
+        juce::NormalisableRange<float>(20.0f, 5000.0f, 0.1f, 0.3f),
+        440.0f,
+        juce::AudioParameterFloatAttributes().withLabel("Hz")));
+
+    layout.add(std::make_unique<juce::AudioParameterChoice>(
+        juce::ParameterID(ParameterIDs::mode, 1),
+        "Mode",
+        juce::StringArray{ "Pitch Track", "Manual" },
+        0));
+
+    layout.add(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID(ParameterIDs::smoothing, 1),
+        "Smoothing",
+        juce::NormalisableRange<float>(0.0f, 100.0f, 0.1f),
+        50.0f,
+        juce::AudioParameterFloatAttributes().withLabel("%")));
+
+    layout.add(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID(ParameterIDs::sensitivity, 1),
+        "Sensitivity",
+        juce::NormalisableRange<float>(0.0f, 100.0f, 0.1f),
+        50.0f,
+        juce::AudioParameterFloatAttributes().withLabel("%")));
+
+    layout.add(std::make_unique<juce::AudioParameterChoice>(
+        juce::ParameterID(ParameterIDs::waveform, 1),
+        "Waveform",
+        juce::StringArray{ "Sine", "Triangle", "Square", "Saw" },
+        0));
+
+    return layout;
 }
 
 void HdnRingmodAudioProcessor::prepareToPlay(double, int)
@@ -52,12 +108,17 @@ void HdnRingmodAudioProcessor::setCurrentProgram(int) {}
 const juce::String HdnRingmodAudioProcessor::getProgramName(int) { return {}; }
 void HdnRingmodAudioProcessor::changeProgramName(int, const juce::String&) {}
 
-void HdnRingmodAudioProcessor::getStateInformation(juce::MemoryBlock&)
+void HdnRingmodAudioProcessor::getStateInformation(juce::MemoryBlock& destData)
 {
+    if (auto xmlState = apvts.copyState().createXml())
+        copyXmlToBinary(*xmlState, destData);
 }
 
-void HdnRingmodAudioProcessor::setStateInformation(const void*, int)
+void HdnRingmodAudioProcessor::setStateInformation(const void* data, int sizeInBytes)
 {
+    if (auto xmlState = getXmlFromBinary(data, sizeInBytes))
+        if (xmlState->hasTagName(apvts.state.getType()))
+            apvts.replaceState(juce::ValueTree::fromXml(*xmlState));
 }
 
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()

--- a/source/PluginProcessor.h
+++ b/source/PluginProcessor.h
@@ -34,6 +34,10 @@ public:
     void getStateInformation(juce::MemoryBlock& destData) override;
     void setStateInformation(const void* data, int sizeInBytes) override;
 
+    juce::AudioProcessorValueTreeState apvts;
+
 private:
+    static juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(HdnRingmodAudioProcessor)
 };


### PR DESCRIPTION
## Summary

- Add ParameterIDs.h with string constants for all 7 parameters
- Add AudioProcessorValueTreeState with full parameter layout (mix, rateMultiplier, manualRate, mode, smoothing, sensitivity, waveform)
- Implement XML state save/load via APVTS serialization

## Test plan

- [ ] CI passes (builds on macOS and Windows)
- [ ] Parameters visible in DAW host
- [ ] State save/load round-trips correctly