### PR TITLE
Fix pitch detection and DSP performance issues

### DIFF
--- a/source/PluginProcessor.h
+++ b/source/PluginProcessor.h
@@ -49,6 +49,7 @@ private:
     YinPitchDetector pitchDetector;
     Oscillator oscillator;
     PitchSmoother pitchSmoother;
+    bool hasValidPitch = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(HdnRingmodAudioProcessor)
 };

--- a/source/dsp/PitchSmoother.h
+++ b/source/dsp/PitchSmoother.h
@@ -1,11 +1,20 @@
 #pragma once
 
+#include <cmath>
+
 class PitchSmoother
 {
 public:
+    inline void prepare(double sampleRate)
+    {
+        sr = static_cast<float>(sampleRate);
+        recomputeAlpha();
+    }
+
     inline void setSmoothingAmount(float amount01)
     {
-        alpha = 1.0f - amount01;
+        smoothingAmount = amount01;
+        recomputeAlpha();
     }
 
     inline void setSensitivity(float sensitivity01)
@@ -30,6 +39,17 @@ public:
     }
 
 private:
+    inline void recomputeAlpha()
+    {
+        float tau = smoothingAmount * 0.2f;
+        if (tau < 1e-6f)
+            alpha = 1.0f;
+        else
+            alpha = 1.0f - std::exp(-1.0f / (sr * tau));
+    }
+
+    float sr = 44100.0f;
+    float smoothingAmount = 0.5f;
     float smoothed = 0.0f;
     float alpha = 0.5f;
     float sensitivityThreshold = 0.5f;

--- a/source/dsp/YinPitchDetector.h
+++ b/source/dsp/YinPitchDetector.h
@@ -18,9 +18,12 @@ public:
 private:
     void analyse();
 
-    double sr = 44100.0;
+    double analysisSR = 44100.0;
     int windowSize = 2048;
     int halfWindow = 1024;
+
+    int decimation = 1;
+    int decimationCounter = 0;
 
     std::vector<float> buffer;
     int writePos = 0;


### PR DESCRIPTION
Addresses all 5 issues from #7.

## Changes

**Issue 1 - Mono sum for pitch analysis**: Averages L+R channels instead of using channel 0 only. Prevents wrong tracking when the right channel carries the dominant signal or stereo content is phase-skewed.

**Issue 2 - YIN CPU reduction via decimation**: Feeds every 2nd sample (or every 4th at >50kHz) to the pitch detector. Reduces analysis cost by 2-8x depending on sample rate while maintaining the same 20-5000Hz detection range. Window size is now always 2048 at the decimated rate.

**Issue 3 - Skip pitch detection in manual mode**: `feedSample()` is no longer called when mode is Manual, eliminating unnecessary CPU usage.

**Issue 4 - Gate wet signal before first valid pitch**: Added `hasValidPitch` flag that prevents ring modulation at the default 440Hz before the detector has locked onto a real pitch. Once a valid pitch is detected, hold-last-good behavior continues as before.

**Issue 5 - Sample-rate independent smoothing**: Smoothing alpha is now computed from a time constant (`tau = amount * 200ms`) using `alpha = 1 - exp(-1/(sr*tau))`. Behavior is consistent across 44.1k, 48k, 96k, etc.

Closes #7