### PR TITLE
Fix tracked ring-mod wet path and YIN interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ This is just a ring modulator, with pitch tracking because there are none that a
 
 This plugin adds **pitch tracking**. It listens to your input, detects the fundamental frequency in real time using the YIN pitch detection algorithm, and locks the modulator oscillator to that pitch. The result is a ring mod effect that tracks what you're playing, producing consistent harmonic relationships regardless of the note. The Rate Multiplier parameter lets you set the ratio between the detected pitch and the oscillator -- 1x gives you octave doubling, 2x gives you a fifth above that, and fractional values produce subharmonic content.
 
-When pitch detection confidence is low (silence, noise, polyphonic content), the effect gracefully fades to dry signal rather than producing artifacts.
-
 The plugin also has a conventional **Manual** mode where the oscillator runs at a fixed frequency, for traditional ring mod sounds.
 
 Four oscillator waveforms are available (sine, triangle, square, saw), each producing a different harmonic character. Square and saw use PolyBLEP anti-aliasing to reduce digital artifacts.
@@ -99,12 +97,12 @@ ctest --test-dir build --build-config Release --output-on-failure
 | Manual Rate     | 20 - 5000 Hz                   | 440 Hz      | Fixed oscillator frequency (Manual mode) |
 | Mode            | Pitch Track / Manual           | Pitch Track | Pitch source selection                   |
 | Smoothing       | 0 - 100%                       | 50%         | Pitch tracking smoothing amount          |
-| Sensitivity     | 0 - 100%                       | 50%         | Pitch detection confidence threshold     |
+| Sensitivity     | 0 - 100%                       | 50%         | Minimum confidence for accepting pitch updates |
 | Waveform        | Sine / Triangle / Square / Saw | Sine        | Ring modulator oscillator shape          |
 
 ## How It Works
 
-In **Pitch Track** mode, the plugin detects the pitch of the incoming audio using the YIN algorithm, then ring-modulates the signal with an oscillator locked to that pitch (multiplied by the Rate Multiplier). The wet signal is confidence-gated so the effect fades in as pitch detection becomes more certain.
+In **Pitch Track** mode, the plugin detects the pitch of the incoming audio using the YIN algorithm, then ring-modulates the signal with an oscillator locked to that pitch (multiplied by the Rate Multiplier). The effect stays dry only until the tracker has a valid pitch, then follows the tracked carrier directly.
 
 In **Manual** mode, the oscillator runs at a fixed frequency set by the Manual Rate knob.
 

--- a/source/PluginProcessor.cpp
+++ b/source/PluginProcessor.cpp
@@ -86,8 +86,8 @@ void HdnRingmodAudioProcessor::prepareToPlay(double sampleRate, int)
     smoothedManualRate.setCurrentAndTargetValue(manualRateParam->load());
 
     float tau = 0.005f;
-    confSmoothAlpha = 1.0f - std::exp(-1.0f / (static_cast<float>(sampleRate) * tau));
-    smoothedWetGain = 0.0f;
+    trackEnableAlpha = 1.0f - std::exp(-1.0f / (static_cast<float>(sampleRate) * tau));
+    smoothedTrackEnable = 0.0f;
 }
 
 void HdnRingmodAudioProcessor::releaseResources()
@@ -140,7 +140,7 @@ void HdnRingmodAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, ju
     for (int i = 0; i < numSamples; ++i)
     {
         float mix = smoothedMix.getNextValue();
-        float wetGain = 1.0f;
+        float effectiveMix = mix;
 
         if (mode == 0)
         {
@@ -151,22 +151,28 @@ void HdnRingmodAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, ju
             pitchDetector.feedSample(monoSample);
 
             auto result = pitchDetector.getResult();
-            wetGain = result.confidence;
-            smoothedWetGain += confSmoothAlpha * (wetGain - smoothedWetGain);
             float smoothedFreq = pitchSmoother.process(result.frequency, result.confidence);
+
+            // Stay dry until the tracker has a pitch, then ramp straight into the tracked carrier.
+            if (smoothedFreq > 0.0f)
+                smoothedTrackEnable += trackEnableAlpha * (1.0f - smoothedTrackEnable);
+            else
+                smoothedTrackEnable = 0.0f;
+
             float oscFreq = smoothedFreq * smoothedRateMult.getNextValue();
 
             if (oscFreq > 0.0f)
                 oscillator.setFrequency(oscFreq);
+
+            effectiveMix *= smoothedTrackEnable;
         }
         else
         {
-            smoothedWetGain = 1.0f;
+            smoothedTrackEnable = 1.0f;
             oscillator.setFrequency(smoothedManualRate.getNextValue());
         }
 
         float oscSample = oscillator.nextSample();
-        float effectiveMix = mix * smoothedWetGain;
 
         for (int ch = 0; ch < numChannels; ++ch)
         {

--- a/source/PluginProcessor.h
+++ b/source/PluginProcessor.h
@@ -54,8 +54,8 @@ private:
     juce::SmoothedValue<float> smoothedRateMult;
     juce::SmoothedValue<float> smoothedManualRate;
 
-    float smoothedWetGain = 1.0f;
-    float confSmoothAlpha = 0.01f;
+    float smoothedTrackEnable = 1.0f;
+    float trackEnableAlpha = 0.01f;
 
     std::atomic<float>* mixParam = nullptr;
     std::atomic<float>* rateMultParam = nullptr;

--- a/source/dsp/YinPitchDetector.cpp
+++ b/source/dsp/YinPitchDetector.cpp
@@ -226,7 +226,7 @@ void YinPitchDetector::analyse()
         float s2 = cmndf[tauEstimate + 1];
         float denom = 2.0f * (2.0f * s1 - s2 - s0);
         if (std::abs(denom) > 1e-12f)
-            betterTau += (s0 - s2) / denom;
+            betterTau += (s2 - s0) / denom;
     }
 
     if (betterTau < 1.0f)

--- a/tests/TestYinPitchDetector.cpp
+++ b/tests/TestYinPitchDetector.cpp
@@ -104,6 +104,20 @@ TEST_CASE("YIN: detects 220 Hz sine at 44100 Hz")
     REQUIRE(result.confidence > 0.5f);
 }
 
+TEST_CASE("YIN: parabolic interpolation is accurate for 110 Hz sine")
+{
+    YinPitchDetector yin;
+    yin.prepare(44100.0);
+
+    feedSine(yin, 44100.0, 110.0f, 44100);
+
+    auto result = yin.getResult();
+    REQUIRE(result.frequency > 0.0f);
+    REQUIRE_THAT(static_cast<double>(result.frequency),
+                 Catch::Matchers::WithinAbs(110.0, 0.2));
+    REQUIRE(result.confidence > 0.5f);
+}
+
 TEST_CASE("YIN: detects E2 (82.4 Hz) at 44100 Hz")
 {
     YinPitchDetector yin;


### PR DESCRIPTION
## Summary
- stop scaling pitch-track wet level by detector confidence and only stay dry until a tracked pitch is available
- fix the sign of the YIN parabolic interpolation offset
- add a tighter 110 Hz detector accuracy test and update the README to match the new tracking behavior

## Testing
- cmake -B build -DCMAKE_BUILD_TYPE=Release -DHDN_BUILD_TESTS=ON
- cmake --build build --config Release
- ctest --test-dir build --build-config Release --output-on-failure